### PR TITLE
Update package.json to eliminate redscreen error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pouchdb-adapter-react-native-sqlite": "^2.0.0",
     "pouchdb-mapreduce": "^7.0.0",
     "react": "16.8.3",
-    "react-native": "0.59.1",
+    "react-native": "0.59.9",
     "react-native-sqlite-2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrading react-native version from 0.59.1 to 0.59.9 in order to remove the error listed below...

```
Unknown argument type '__attribute__' in method -[RCTAppState getCurrentAppState:error:]. Extend RCTConvert to support this type.

-[RCTModuleMethod processMethodSignature]
    RCTModuleMethod.mm:375
-[RCTModuleMethod invokeWithBridge:module:arguments:]
facebook::react::invokeInner(RCTBridge*, RCTModuleData*, unsigned int, folly::dynamic const&)
facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_0::operator()() const
invocation function for block in facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int)
_dispatch_call_block_and_release
_dispatch_client_callout
_dispatch_main_queue_callback_4CF
__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
__CFRunLoopRun
CFRunLoopRunSpecific
GSEventRunModal
UIApplicationMain
main
start
0x0
```